### PR TITLE
Enable yarn's 'workspaces-experimental'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash \
         unzip \
         fontforge
 
+RUN yarn config set workspaces-experimental true
+
 RUN apt-get clean && rm -Rf /var/cache/apt
 
 # Set the locale to avoid active_model_serializers bundler install failure


### PR DESCRIPTION
I had been receiving
'error The workspace feature is currently experimental and needs to be
manually enabled - please add "workspaces-experimental true" to your
.yarnrc file.'

So I added 'RUN yarn config set workspaces-experimental true' right
after the installation of yarn, and the error did not appear on next
runtime.

resolves: #18