### PR TITLE
Fixoutdated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY --chown=canvasuser assets/redis.yml config/redis.yml
 COPY --chown=canvasuser assets/cache_store.yml config/cache_store.yml
 COPY --chown=canvasuser assets/development-local.rb config/environments/development-local.rb
 COPY --chown=canvasuser assets/outgoing_mail.yml config/outgoing_mail.yml
+COPY assets/healthcheck.sh /usr/local/bin/healthcheck.sh
 
 RUN for config in amazon_s3 delayed_jobs domain file_store security external_migration \
        ; do cp config/$config.yml.example config/$config.yml \
@@ -91,5 +92,8 @@ EXPOSE 5432
 EXPOSE 6379
 # canvas
 EXPOSE 3000
+
+HEALTHCHECK --interval=3m --start-period=5m \
+   CMD /usr/local/bin/healthcheck.sh
 
 CMD ["/opt/canvas/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Jay Luker <jay_luker@harvard.edu>
 ARG REVISION=master
 ENV RAILS_ENV development
 ENV GEM_HOME /opt/canvas/.gems
+ENV GEM_PATH /opt/canvas/.gems:/opt/canvas/.gem/ruby/2.7.0
 ENV DEBIAN_FRONTEND noninteractive
 
 # add nodejs and recommended ruby repos
@@ -42,18 +43,13 @@ ENV LC_ALL en_US.UTF-8
 RUN groupadd -r canvasuser -g 433 && \
     adduser --uid 431 --system --gid 433 --home /opt/canvas canvasuser && \
     adduser canvasuser sudo && \
-    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL\nDefaults env_keep += "GEM_HOME RAILS_ENV REVISION LANG LANGUAGE LC_ALL"' >> /etc/sudoers
 
-RUN if [ -e /var/lib/gems/$RUBY_MAJOR.0/gems/bundler-* ]; then BUNDLER_INSTALL="-i /var/lib/gems/$RUBY_MAJOR.0"; fi \
-  && mkdir -p $GEM_HOME \
-  && gem uninstall --all --ignore-dependencies --force $BUNDLER_INSTALL bundler \
-  && gem install bundler --no-document -v 2.2.19 \
-  && chown -R canvasuser: $GEM_HOME
+RUN sudo -u canvasuser mkdir -p $GEM_HOME \
+  && sudo -u canvasuser gem install --user-install bundler:2.2.19 --no-document
 
-#RUN gem install bundler --version 1.14.6
-
-COPY assets/dbinit.sh /opt/canvas/dbinit.sh
-COPY assets/start.sh /opt/canvas/start.sh
+COPY --chown=canvasuser assets/dbinit.sh /opt/canvas/dbinit.sh
+COPY --chown=canvasuser assets/start.sh /opt/canvas/start.sh
 RUN chmod 755 /opt/canvas/*.sh
 
 COPY assets/supervisord.conf /etc/supervisor/supervisord.conf
@@ -61,32 +57,31 @@ COPY assets/pg_hba.conf /etc/postgresql/12/main/pg_hba.conf
 RUN sed -i "/^#listen_addresses/i listen_addresses='*'" /etc/postgresql/12/main/postgresql.conf
 
 RUN cd /opt/canvas \
-    && git clone https://github.com/instructure/canvas-lms.git \
+    && sudo -u canvasuser git clone https://github.com/instructure/canvas-lms.git \
     && cd canvas-lms \
-    && git checkout $REVISION
+    && sudo -u canvasuser git checkout $REVISION
 
 WORKDIR /opt/canvas/canvas-lms
 
-COPY assets/database.yml config/database.yml
-COPY assets/redis.yml config/redis.yml
-COPY assets/cache_store.yml config/cache_store.yml
-COPY assets/development-local.rb config/environments/development-local.rb
-COPY assets/outgoing_mail.yml config/outgoing_mail.yml
+COPY --chown=canvasuser assets/database.yml config/database.yml
+COPY --chown=canvasuser assets/redis.yml config/redis.yml
+COPY --chown=canvasuser assets/cache_store.yml config/cache_store.yml
+COPY --chown=canvasuser assets/development-local.rb config/environments/development-local.rb
+COPY --chown=canvasuser assets/outgoing_mail.yml config/outgoing_mail.yml
 
 RUN for config in amazon_s3 delayed_jobs domain file_store security external_migration \
        ; do cp config/$config.yml.example config/$config.yml \
        ; done
 
-RUN $GEM_HOME/bin/bundle install --jobs 8 --without="mysql"
-RUN yarn install --pure-lockfile
-RUN COMPILE_ASSETS_NPM_INSTALL=0 $GEM_HOME/bin/bundle exec rake canvas:compile_assets_dev
+RUN sudo -u canvasuser /opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ install --jobs 8 --without="mysql"
+RUN sudo -u canvasuser yarn install --pure-lockfile
+RUN sudo -u canvasuser COMPILE_ASSETS_NPM_INSTALL=0 /opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rake canvas:compile_assets_dev
 
-RUN mkdir -p log tmp/pids public/assets public/stylesheets/compiled \
-    && touch Gemmfile.lock
+RUN sudo -u canvasuser mkdir -p log tmp/pids public/assets public/stylesheets/compiled \
+    && sudo -u canvasuser touch Gemmfile.lock
 
-RUN service postgresql start && /opt/canvas/dbinit.sh
+RUN service postgresql start && sudo -u canvasuser /opt/canvas/dbinit.sh
 
-RUN chown -R canvasuser: /opt/canvas
 RUN chown -R canvasuser: /tmp/attachment_fu/
 
 # postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV ASDF_DATA_DIR=/opt/canvas/.asdf
 
 # add nodejs and recommended ruby repos
 RUN apt-get update \
-    && apt-get install -y autoconf build-essential curl curl fontforge g++ git libcurl4-openssl-dev libicu-dev \
+    && apt-get install -y autoconf build-essential curl curl file fontforge g++ git libcurl4-openssl-dev libicu-dev \
     libidn-dev libpq-dev libffi-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
     libxslt1-dev libyaml-dev make postgresql postgresql-contrib redis-server \
     software-properties-common sudo supervisor unzip zlib1g-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM ubuntu:24.10
+FROM ubuntu:25.10
 
-MAINTAINER Jay Luker <jay_luker@harvard.edu>
-
-ARG RUBY_VERSION=3.3.0
-ARG POSTGRES_VERSION=16
-ARG BUNDLER_VERSION=2.5.10
+ARG RUBY_VERSION=3.4.8
+ARG POSTGRES_VERSION=17
+ARG BUNDLER_VERSION=2.6.7
 ARG REVISION=master
-ENV RAILS_ENV development
-ENV GEM_HOME /opt/canvas/.gems
-ENV GEM_PATH ${GEM_HOME}:/opt/canvas/.gem/ruby/${RUBY_VERSION}
-ENV DEBIAN_FRONTEND noninteractive
+ENV RAILS_ENV=development
+ENV GEM_HOME=/opt/canvas/.gems
+ENV GEM_PATH=${GEM_HOME}:/opt/canvas/.gem/ruby/${RUBY_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ASDF_DATA_DIR=/opt/canvas/.asdf
 
 # add nodejs and recommended ruby repos
 RUN apt-get update \
-    && apt-get install -y autoconf curl curl fontforge g++ git libicu-dev \
-    libidn-dev libpq-dev libsqlite3-dev libxml2-dev libxmlsec1-dev \
-    libxslt1-dev make postgresql postgresql-contrib redis-server ruby ruby-dev \
+    && apt-get install -y autoconf build-essential curl curl fontforge g++ git libcurl4-openssl-dev libicu-dev \
+    libidn-dev libpq-dev libffi-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
+    libxslt1-dev libyaml-dev make postgresql postgresql-contrib redis-server \
     software-properties-common sudo supervisor unzip zlib1g-dev \
     && apt-get clean && rm -Rf /var/cache/apt
 
@@ -26,29 +25,32 @@ RUN curl -sSL -o apache-pulsar-client-dev.deb https://archive.apache.org/dist/pu
   && rm apache-pulsar-client-dev.deb apache-pulsar-client.deb
 
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \
-        yarn \
         unzip \
         fontforge \
     && apt-get clean && rm -Rf /var/cache/apt
 
+RUN npm install -g yarn
+
+RUN cd /bin && curl -sSL -o asdf.tar.gz https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz && tar xzf asdf.tar.gz && rm asdf.tar.gz && cd -
+
 # Set the locale to avoid active_model_serializers bundler install failure
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 RUN groupadd -r canvasuser -g 433 && \
     adduser --uid 431 --system --gid 433 --home /opt/canvas canvasuser && \
     adduser canvasuser sudo && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL\nDefaults env_keep += "GEM_HOME GEM_PATH RAILS_ENV REVISION LANG LANGUAGE LC_ALL"' >> /etc/sudoers
 
-RUN sudo -u canvasuser mkdir -p $GEM_HOME \
-  && sudo -u canvasuser gem install --user-install bundler:${BUNDLER_VERSION} --no-document
+RUN sudo -u canvasuser asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git && sudo -u canvasuser asdf install ruby $RUBY_VERSION && sudo -u canvasuser asdf set -u ruby $RUBY_VERSION
+
+RUN sudo -u canvasuser mkdir -p $GEM_HOME
+#RUN sudo -u canvasuser sh -c 'PATH=$PATH:$HOME/.asdf/shims gem install --user-install bundler:${BUNDLER_VERSION} --no-document'
 
 COPY --chown=canvasuser assets/dbinit.sh /opt/canvas/dbinit.sh
 COPY --chown=canvasuser assets/start.sh /opt/canvas/start.sh
@@ -63,6 +65,10 @@ RUN cd /opt/canvas \
 
 WORKDIR /opt/canvas/canvas-lms
 
+RUN cd config && for config in ls *.yml.example \
+       ; do cp ${config} ${config%.example} \
+       ; done && rm consul.yml vault.yml && touch consul.yml vault.yml
+
 COPY --chown=canvasuser assets/database.yml config/database.yml
 COPY --chown=canvasuser assets/domain.yml config/domain.yml
 COPY --chown=canvasuser assets/redis.yml config/redis.yml
@@ -71,11 +77,7 @@ COPY --chown=canvasuser assets/development-local.rb config/environments/developm
 COPY --chown=canvasuser assets/outgoing_mail.yml config/outgoing_mail.yml
 COPY assets/healthcheck.sh /usr/local/bin/healthcheck.sh
 
-RUN for config in amazon_s3 delayed_jobs domain file_store security external_migration \
-       ; do cp config/$config.yml.example config/$config.yml \
-       ; done
-
-ARG BUNDLE=/opt/canvas/.local/share/gem/ruby/${RUBY_VERSION}/bin/bundle
+ARG BUNDLE=/opt/canvas/.asdf/shims/bundle
 RUN sudo -u canvasuser ${BUNDLE} config set --local without 'development:test' \
   &&sudo -u canvasuser ${BUNDLE} config set --local without 'mysql' \
   && sudo -u canvasuser ${BUNDLE} install --jobs 8

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ COPY --chown=canvasuser assets/redis.yml config/redis.yml
 COPY --chown=canvasuser assets/cache_store.yml config/cache_store.yml
 COPY --chown=canvasuser assets/development-local.rb config/environments/development-local.rb
 COPY --chown=canvasuser assets/outgoing_mail.yml config/outgoing_mail.yml
+COPY --chown=canvasuser assets/security.yml config/security.yml
 COPY assets/healthcheck.sh /usr/local/bin/healthcheck.sh
 
 ARG BUNDLE=/opt/canvas/.asdf/shims/bundle

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@
 
 ## Running
 
-`docker run --name canvas-docker -p 3000:3000 -d lbjay/canvas-docker`
+**NOTE** The rails server will send a `500` error for the landing page when started for the first time. This can be resolved by restarting the container after it is fully initialized.
+
+    docker run --name canvas-docker -p 3000:3000 -d lbjay/canvas-docker
+    # Wait for the services to finish starting up then press ctrl-c to stop the container
+    docker start canvas-docker
 
 This repo is [registered](https://registry.hub.docker.com/u/lbjay/canvas-docker/) at Docker Hub as an automated build. So you should also be able to `docker pull lbjay/canvas-docker` to get the pre-built image.
 
@@ -22,7 +26,8 @@ This repo is [registered](https://registry.hub.docker.com/u/lbjay/canvas-docker/
 1. Clone this repo somewhere. 
 2. Build the image: `docker build -t canvas-docker .`
 3. Start the container: `docker run -t -i -p 3000:3000 --name canvas-docker canvas-docker`
-4. Point your browser to [http://localhost:3000](http://localhost:3000). The admin user/pass login is `canvas@example.edu` / `canvas-docker`.
+4. Wait for the services to finish starting up then press `ctrl-c` to stop the container and run `docker start canvas-docker`
+5. Point your browser to [http://localhost:3000](http://localhost:3000). The admin user/pass login is `canvas@example.edu` / `canvas-docker`.
 
 ## The "fat" container
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@
 
 ## Running
 
-**NOTE** The rails server will send a `500` error for the landing page when started for the first time. This can be resolved by restarting the container after it is fully initialized.
-
-    docker run --name canvas-docker -p 3000:3000 -d lbjay/canvas-docker
-    # Wait for the services to finish starting up then press ctrl-c to stop the container
-    docker start canvas-docker
+`docker run --name canvas-docker -p 3000:3000 -d lbjay/canvas-docker`
 
 This repo is [registered](https://registry.hub.docker.com/u/lbjay/canvas-docker/) at Docker Hub as an automated build. So you should also be able to `docker pull lbjay/canvas-docker` to get the pre-built image.
 
@@ -26,8 +22,7 @@ This repo is [registered](https://registry.hub.docker.com/u/lbjay/canvas-docker/
 1. Clone this repo somewhere. 
 2. Build the image: `docker build -t canvas-docker .`
 3. Start the container: `docker run -t -i -p 3000:3000 --name canvas-docker canvas-docker`
-4. Wait for the services to finish starting up then press `ctrl-c` to stop the container and run `docker start canvas-docker`
-5. Point your browser to [http://localhost:3000](http://localhost:3000). The admin user/pass login is `canvas@example.edu` / `canvas-docker`.
+4. Point your browser to [http://localhost:3000](http://localhost:3000). The admin user/pass login is `canvas@example.edu` / `canvas-docker`.
 
 ## The "fat" container
 

--- a/assets/cache_store.yml
+++ b/assets/cache_store.yml
@@ -1,8 +1,8 @@
 test:
-  cache_store: redis_store
+  cache_store: redis_cache_store
 
 development:
-  cache_store: redis_store
+  cache_store: redis_cache_store
 
 production:
-  cache_store: redis_store
+  cache_store: redis_cache_store

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export POSTGRES_BIN=/usr/lib/postgresql/9.3/bin
+export POSTGRES_BIN=/usr/lib/postgresql/12/bin
 
 sudo -u postgres $POSTGRES_BIN/createuser --superuser canvas
 sudo -u postgres $POSTGRES_BIN/createdb -E UTF-8 -T template0 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8 --owner canvas canvas_$RAILS_ENV
@@ -15,7 +15,7 @@ export CANVAS_LMS_STATS_COLLECTION="opt_out"
 cd /opt/canvas/canvas-lms \
     && $GEM_HOME/bin/bundle exec rake db:initial_setup
 
-psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000');"
+psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1);"
 
 # 'crypted_token' value is hmac sha1 of 'canvas-docker' using default config/security.yml encryption_key value as secret
-psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', '', now(), 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"
+psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id, root_account_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', '', now(), 1, 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -20,4 +20,4 @@ psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, em
 # 'crypted_token' value is hmac sha1 of 'canvas-docker' using default config/security.yml encryption_key value as secret
 psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id, root_account_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', 'canva', now(), 1, 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"
 
-psql -U canvas -d canvas_development -c "INSERT INTO developer_key_account_bindings (account_id, developer_key_id, workflow_state, created_at, root_account_id) SELECT 1, dk.id, 'on', now(), 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"
+psql -U canvas -d canvas_development -c "INSERT INTO developer_key_account_bindings (account_id, developer_key_id, workflow_state, created_at, updated_at, root_account_id) SELECT 1, dk.id, 'on', now(), now(), 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -13,7 +13,7 @@ export CANVAS_LMS_ACCOUNT_NAME="Canvas Docker"
 export CANVAS_LMS_STATS_COLLECTION="opt_out"
 
 cd /opt/canvas/canvas-lms \
-    && $GEM_HOME/bin/bundle exec rake db:initial_setup
+    && /opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rake db:initial_setup
 
 psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1);"
 

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -15,7 +15,9 @@ export CANVAS_LMS_STATS_COLLECTION="opt_out"
 cd /opt/canvas/canvas-lms \
     && /opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rake db:initial_setup
 
-psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1);"
+psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id, access_token_count) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1, 1);"
 
 # 'crypted_token' value is hmac sha1 of 'canvas-docker' using default config/security.yml encryption_key value as secret
-psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id, root_account_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', '', now(), 1, 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"
+psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id, root_account_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', 'canva', now(), 1, 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"
+
+psql -U canvas -d canvas_development -c "INSERT INTO developer_key_account_bindings (account_id, developer_key_id, workflow_state, created_at, root_account_id) SELECT 1, dk.id, 'on', now(), 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export POSTGRES_BIN=/usr/lib/postgresql/12/bin
+export POSTGRES_BIN=/usr/lib/postgresql/16/bin
 
 sudo -u postgres $POSTGRES_BIN/createuser --superuser canvas
 sudo -u postgres $POSTGRES_BIN/createdb -E UTF-8 -T template0 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8 --owner canvas canvas_$RAILS_ENV
@@ -13,9 +13,9 @@ export CANVAS_LMS_ACCOUNT_NAME="Canvas Docker"
 export CANVAS_LMS_STATS_COLLECTION="opt_out"
 
 cd /opt/canvas/canvas-lms \
-    && /opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rake db:initial_setup
+    && /opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec rake db:initial_setup
 
-psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id, access_token_count) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1, 1);"
+psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id, access_token_count, created_at, updated_at) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1, 1, now(), now());"
 
 # 'crypted_token' value is hmac sha1 of 'canvas-docker' using default config/security.yml encryption_key value as secret
 psql -U canvas -d canvas_development -c "INSERT INTO access_tokens (created_at, crypted_token, developer_key_id, purpose, token_hint, updated_at, user_id, root_account_id) SELECT now(), '4bb5b288bb301d3d4a691ebff686fc67ad49daa8', dk.id, 'canvas-docker', 'canva', now(), 1, 1 FROM developer_keys dk where dk.email = 'canvas@example.edu';"

--- a/assets/dbinit.sh
+++ b/assets/dbinit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export POSTGRES_BIN=/usr/lib/postgresql/16/bin
+export POSTGRES_BIN=/usr/lib/postgresql/17/bin
 
 sudo -u postgres $POSTGRES_BIN/createuser --superuser canvas
 sudo -u postgres $POSTGRES_BIN/createdb -E UTF-8 -T template0 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8 --owner canvas canvas_$RAILS_ENV
@@ -13,7 +13,7 @@ export CANVAS_LMS_ACCOUNT_NAME="Canvas Docker"
 export CANVAS_LMS_STATS_COLLECTION="opt_out"
 
 cd /opt/canvas/canvas-lms \
-    && /opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec rake db:initial_setup
+    && /opt/canvas/.asdf/shims/bundle exec rake db:initial_setup
 
 psql -U canvas -d canvas_development -c "INSERT INTO developer_keys (api_key, email, name, redirect_uri, root_account_id, access_token_count, created_at, updated_at) VALUES ('test_developer_key', 'canvas@example.edu', 'Canvas Docker', 'http://localhost:8000', 1, 1, now(), now());"
 

--- a/assets/domain.yml
+++ b/assets/domain.yml
@@ -1,0 +1,16 @@
+test:
+  domain: localhost
+
+development:
+  domain: "canvas.127.0.0.1.nip.io"
+  # If you want to set up SSL and a separate files domain, use the following and set up puma-dev from github.com/puma/puma-dev
+  # domain: "canvas-lms.test" # for puma-dev
+  # files_domain: "canvas-lms.files" # for puma-dev
+  # ssl: true
+
+production:
+  domain: "canvas.example.com"
+  # whether this instance of canvas is served over ssl (https) or not
+  # defaults to true for production, false for test/development
+  ssl: true
+  # files_domain: "canvasfiles.example.com"

--- a/assets/healthcheck.sh
+++ b/assets/healthcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+STATUS=$(/usr/bin/curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000")
+if [ "$STATUS" == "500" ]
+then
+  /usr/bin/supervisorctl restart canvas_web
+fi

--- a/assets/redis.yml
+++ b/assets/redis.yml
@@ -1,9 +1,6 @@
 test:
-  servers:
-    - "redis://localhost"
-  database: 1
+  host: "localhost"
+  db: 1
 
 development:
-  servers:
-    - "redis://localhost"
-
+  host: "localhost"

--- a/assets/security.yml
+++ b/assets/security.yml
@@ -1,0 +1,22 @@
+production: &default
+  # replace this with a random string of at least 20 characters
+  encryption_key: 12345
+  # replace this with a random string of 64 characters
+  # First one is used for encryption; all are used for decryption
+  jwt_encryption_keys:
+    - 12345
+  lti_iss: 'https://canvas.127.0.0.1.nip.io'
+
+development:
+  <<: *default
+  encryption_key: facdd3a131ddd8988b14f6e4e01039c93cfa0160
+  previous_encryption_keys:
+    - 0610afc39c93010e4e6f41b8898ddd131a3ddcaf
+  jwt_encryption_keys:
+    - 68ddd5576efad4bc90eed3ab0543a1112b0f51ec9425573a80a96cbc4a9e12b6
+
+test:
+  <<: *default
+  encryption_key: facdd3a131ddd8988b14f6e4e01039c93cfa0160
+  jwt_encryption_keys:
+    - 68ddd5576efad4bc90eed3ab0543a1112b0f51ec9425573a80a96cbc4a9e12b6

--- a/assets/supervisord.conf
+++ b/assets/supervisord.conf
@@ -24,7 +24,7 @@ priority=2
 [program:canvas_web]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=%(ENV_GEM_HOME)s/bin/bundle exec rails server -b 0.0.0.0
+command=/opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rails server -b 0.0.0.0
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -32,4 +32,4 @@ redirect_stderr=true
 [program:canvas_worker]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=%(ENV_GEM_HOME)s/bin/bundle exec script/delayed_job run
+command=/opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec script/delayed_job run

--- a/assets/supervisord.conf
+++ b/assets/supervisord.conf
@@ -13,7 +13,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 [program:postgres]
 user=postgres
-command=/usr/lib/postgresql/9.3/bin/postgres --config-file=/etc/postgresql/9.3/main/postgresql.conf
+command=/usr/lib/postgresql/12/bin/postgres --config-file=/etc/postgresql/12/main/postgresql.conf
 priority=1
 
 [program:redis]

--- a/assets/supervisord.conf
+++ b/assets/supervisord.conf
@@ -13,7 +13,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 [program:postgres]
 user=postgres
-command=/usr/lib/postgresql/12/bin/postgres --config-file=/etc/postgresql/12/main/postgresql.conf
+command=/usr/lib/postgresql/16/bin/postgres --config-file=/etc/postgresql/16/main/postgresql.conf
 priority=1
 
 [program:redis]
@@ -24,7 +24,7 @@ priority=2
 [program:canvas_web]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=/opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec rails server -b 0.0.0.0
+command=/opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec rails server -b 0.0.0.0
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -32,4 +32,4 @@ redirect_stderr=true
 [program:canvas_worker]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=/opt/canvas/.gem/ruby/2.7.0/bin/bundle _2.2.19_ exec script/delayed_job run
+command=/opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec script/delayed_job run

--- a/assets/supervisord.conf
+++ b/assets/supervisord.conf
@@ -13,7 +13,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 [program:postgres]
 user=postgres
-command=/usr/lib/postgresql/16/bin/postgres --config-file=/etc/postgresql/16/main/postgresql.conf
+command=/usr/lib/postgresql/17/bin/postgres --config-file=/etc/postgresql/17/main/postgresql.conf
 priority=1
 
 [program:redis]
@@ -24,7 +24,7 @@ priority=2
 [program:canvas_web]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=/opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec rails server -b 0.0.0.0
+command=/opt/canvas/.asdf/shims/bundle exec rails server -b 0.0.0.0
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
@@ -32,4 +32,4 @@ redirect_stderr=true
 [program:canvas_worker]
 user=canvasuser
 directory=/opt/canvas/canvas-lms
-command=/opt/canvas/.local/share/gem/ruby/3.3.0/bin/bundle exec script/delayed_job run
+command=/opt/canvas/.asdf/shims/bundle exec script/delayed_job run


### PR DESCRIPTION
Updates to use more recent versions of build tools, the old versions can no longer build canvas-lms. Also fixes for docker image bloat/slowdown caused by using `chown -R`